### PR TITLE
fix: CRW-1260 improve rhel.Dockerfile so it works w/ Brew requirements; update to newer base images, fix typos, etc.

### DIFF
--- a/build/dockerfiles/brew.Dockerfile
+++ b/build/dockerfiles/brew.Dockerfile
@@ -1,0 +1,23 @@
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# this container build continues from rhel.Dockerfile and rhel.Dockefile.extract.assets.sh
+# assumes you have created asset-*.tar.gz files for all arches, but you'll only unpack the one for your arch
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
+FROM ubi8-minimal:8.2-349
+USER appuser
+COPY asset-*.tar.gz /tmp/assets/
+RUN tar xzf /tmp/asset/asset-configbump-$(uname -m).tar.gz -C / && \
+    rm -fr /tmp/assets/
+ENTRYPOINT ["configbump"]
+
+# append Brew metadata here

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -19,7 +19,6 @@ ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:$PATH \
     GOOS=linux
 WORKDIR /go/src/github.com/che-incubator/configbump
 COPY go.mod go.sum ./
-# TODO: will this work in Brew? :: Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download && go mod verify
 COPY . /go/src/github.com/che-incubator/configbump
 RUN adduser appuser && \
@@ -27,11 +26,6 @@ RUN adduser appuser && \
     export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.2-349
-USER appuser
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /go/src/github.com/che-incubator/configbump/configbump /usr/local/bin
-ENTRYPOINT ["configbump"]
-
-# append Brew metadata here
+# now collect assets into a tarball, and in brew.Dockerfile, extract and use them
+# if doing steps locally, run ./build/dockerfiles/rhel.Dockerfile.extract.assets.sh
+# if running in Jenkins, see https://github.com/redhat-developer/codeready-workspaces/tree/crw-2.5-rhel-8/dependencies/configbump/Jenkinsfile (or newer branch) for script

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -24,7 +24,8 @@ COPY . /go/src/github.com/che-incubator/configbump
 RUN adduser appuser && \
     go test -v  ./... && \
     export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go && \
+    cp /go/src/github.com/che-incubator/configbump/configbump /usr/local/bin/configbump
 
 # now collect assets into a tarball, and in brew.Dockerfile, extract and use them
 # if doing steps locally, run ./build/dockerfiles/rhel.Dockerfile.extract.assets.sh

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -24,13 +24,13 @@ USER root
 WORKDIR /go/src/github.com/che-incubator/configbump
 # copy go.mod go.sum
 COPY go.mod go.sum ./
-# Get dependancies - will also be cached if we won't change mod/sum
+# Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download && go mod verify
 COPY . /go/src/github.com/che-incubator/configbump
 RUN go test -v  ./...
 RUN adduser appuser && \
-    go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
-
+    export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
+    GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.2-267

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -17,7 +17,7 @@ ENV GOOS=linux
 ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:$PATH
 # DOWNSTREAM: use rhel8/go-toolset; no path modification needed
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
-# FROM registry.redhat.io/rhel8/go-toolset:1.13.4-15 as builder
+# FROM registry.redhat.io/rhel8/go-toolset:1.13.15-1 as builder
 
 ENV GOPATH=/go/
 USER root
@@ -33,7 +33,7 @@ RUN adduser appuser && \
     GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.2-267
+FROM registry.access.redhat.com/ubi8-minimal:8.2-349
 USER appuser
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/che-incubator/configbump/configbump /usr/local/bin

--- a/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
+++ b/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -xe
 
 # Copyright (c) 2020 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -22,9 +23,9 @@ rm -fr ${TMPDIR} ${WORKSPACE}/asset-configbump-*.tar.gz
 
 for d in usr/local/bin/configbump etc/passwd; do
     mkdir -p ${TMPDIR}/${d%/*}
-    ${PODMAN} run --rm --entrypoint cat $TMPIMG ${d} > ${TMPDIR}/${d}
+    ${PODMAN} run --rm --entrypoint cat $TMPIMG /${d} > ${TMPDIR}/${d}
 done
-# tree ${TMPDIR}
+tree ${TMPDIR}
 
 pushd ${TMPDIR} >/dev/null || exit 1
     tar cvzf "${WORKSPACE}/asset-configbump-$(uname -m).tar.gz" ./

--- a/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
+++ b/build/dockerfiles/rhel.Dockerfile.extract.assets.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+# script to build rhel.Dockerfile and extract relevant assets for reuse in Brew
+
+TMPIMG=configbump:local
+PODMAN=podman; if [[ ! $(which podman) ]]; then PODMAN=docker;fi
+${PODMAN} build . -f build/dockerfiles/rhel.Dockerfile -t ${TMPIMG}
+
+# create asset-* files
+TMPDIR=$(mktemp -d)
+rm -fr ${TMPDIR} ${WORKSPACE}/asset-configbump-*.tar.gz
+
+for d in usr/local/bin/configbump etc/passwd; do
+    mkdir -p ${TMPDIR}/${d%/*}
+    ${PODMAN} run --rm --entrypoint cat $TMPIMG ${d} > ${TMPDIR}/${d}
+done
+# tree ${TMPDIR}
+
+pushd ${TMPDIR} >/dev/null || exit 1
+    tar cvzf "${WORKSPACE}/asset-configbump-$(uname -m).tar.gz" ./
+popd >/dev/null || exit 1
+
+${PODMAN} rmi -f ${TMPIMG}
+rm -fr ${TMPDIR}


### PR DESCRIPTION
ensure go build is arch-aware; fix typo
bump to latest base images
clean up header and add note about 'go mod download' not yet working in Brew

Change-Id: I4b1b003eec4d8df259e15a5fe6acc9149559cec7
Signed-off-by: nickboldt <nboldt@redhat.com>