### PR TITLE
chore: Use new ubi go-toolset as builder; use ubi8-micro for runtime

### DIFF
--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -29,7 +29,7 @@ RUN adduser appuser && \
     CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
     
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-micro
-FROM registry.access.redhat.com/ubi8-micro:8.4
+FROM registry.access.redhat.com/ubi8-micro:8.4-72
 USER appuser
 COPY --from=builder /app/configbump /usr/local/bin/configbump
 ENTRYPOINT [ "/usr/local/bin/configbump" ]

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -9,12 +9,11 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# UPSTREAM: use devtools/go-toolset-rhel7 image so we're not required to authenticate with registry.redhat.io
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/devtools/go-toolset-rhel7
-FROM registry.access.redhat.com/devtools/go-toolset-rhel7:1.13.15-4 as builder
-# remember to update path when golang version changes (1.13 -> 1.14)
-ENV PATH=/opt/rh/go-toolset-1.13/root/usr/bin:$PATH \
-    GOPATH=/go/ \
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal:8.4-200.1622548483 as builder
+RUN microdnf install -y golang
+
+ENV GOPATH=/go/ \
     CGO_ENABLED=0 \
     GOOS=linux
 USER root

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -9,24 +9,27 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.4-200.1622548483 as builder
-RUN microdnf install -y golang
-
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.15.7-11 as builder
 ENV GOPATH=/go/ \
     CGO_ENABLED=0 \
     GOOS=linux
 USER root
-WORKDIR /go/src/github.com/che-incubator/configbump
-COPY go.mod go.sum ./
+WORKDIR /app
+ENV GO111MODULE on
+# ENV GOPROXY https://goproxy.io
+COPY go.mod .
+COPY go.sum .
 RUN go mod download && go mod verify
-COPY . /go/src/github.com/che-incubator/configbump
+COPY . ./
+
 RUN adduser appuser && \
     go test -v  ./... && \
     export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go && \
-    cp /go/src/github.com/che-incubator/configbump/configbump /usr/local/bin/configbump
-
-# now collect assets into a tarball, and in brew.Dockerfile, extract and use them
-# if doing steps locally, run ./build/dockerfiles/rhel.Dockerfile.extract.assets.sh
-# if running in Jenkins, see https://gitlab.cee.redhat.com/codeready-workspaces/crw-jenkins/-/blob/master/jobs/CRW_CI/crw-configbump_2.6.jenkinsfile (or newer) for script
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -a -ldflags '-w -s' -a -installsuffix cgo -o configbump cmd/configbump/main.go
+    
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-micro
+FROM registry.access.redhat.com/ubi8-micro:8.4
+USER appuser
+COPY --from=builder /app/configbump /usr/local/bin/configbump
+ENTRYPOINT [ "/usr/local/bin/configbump" ]

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/che-incubator/configbump
 
-go 1.12
+go 1.15
 
 require (
 	github.com/alexflint/go-arg v1.3.0


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Use ubi8 minimal in rhel Dockerfile. Upgrade golang to 1.15

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19762