### PR TITLE
Add job that create bugfix branches along with upstream Che release

### DIFF
--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -1,0 +1,31 @@
+name: Create branch
+on:
+  # to be run once every 3 weeks for a 7.yy.0 release, so we can get a stable 7.yy.x branch for use by downstream consumers
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to create. Should be in format 7.yy.x'
+        required: true
+      branchfrom:
+        description: 'The source branch from which to branch, eg., main'
+        default: 'main'
+      forceflag:
+        description: 'To force creation of .x branch, use --force flag here'
+        default: ''
+jobs:
+  build:
+    name: Create branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
+      - name: Create branch
+        run: |
+          git config --global user.name "Mykhailo Kuznietsov"
+          git config --global user.email "mkuznets@redhat.com"
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          curl https://raw.githubusercontent.com/eclipse-che/che-release/main/make-branch.sh | bash -s -- \
+          --branch ${{ github.event.inputs.branch }} \
+          --branchfrom ${{ github.event.inputs.branchfrom }} \
+          --repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -28,4 +28,5 @@ jobs:
           curl https://raw.githubusercontent.com/eclipse-che/che-release/main/make-branch.sh | bash -s -- \
           --branch ${{ github.event.inputs.branch }} \
           --branchfrom ${{ github.event.inputs.branchfrom }} \
-          --repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
+          --repo "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}" \
+          ${{ github.event.inputs.forceflag }}

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -24,7 +24,6 @@ jobs:
         run: |
           git config --global user.name "Mykhailo Kuznietsov"
           git config --global user.email "mkuznets@redhat.com"
-          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           curl https://raw.githubusercontent.com/eclipse-che/che-release/main/make-branch.sh | bash -s -- \
           --branch ${{ github.event.inputs.branch }} \
           --branchfrom ${{ github.event.inputs.branchfrom }} \


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Add job that creates bugifx branches (e.g 7.33.x) with each release of Upstream Che. This is needed for CRW, so that downstream project will be build from those branches

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/20053