### PR TITLE
Chore: update ubuntu to 22.04 and actions to use node 16 for #21763

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -31,11 +31,11 @@ on:
 jobs:
 
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
       -
         name: Prepare
         id: prepare
@@ -45,12 +45,12 @@ jobs:
           fi
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.13
       -
         name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -63,12 +63,12 @@ jobs:
         name: Go test
         run: go test -v  ./...
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: go
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
       -
         name: Prepare
         id: prepare

--- a/.github/workflows/make-branch.yml
+++ b/.github/workflows/make-branch.yml
@@ -15,9 +15,9 @@ on:
 jobs:
   build:
     name: Create branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           fetch-depth: 0
       - name: Create branch


### PR DESCRIPTION
Signed-off-by: sdawley <sdawley@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Updates Ubuntu to 22.04 and uses actions that have been updated to use node 16 wherever possible.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21763