### PR TITLE
Chore: CRW-4582 this particular sha DOES require openssl-fips

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,5 +11,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	sigs.k8s.io/controller-runtime v0.2.1
-	github.com/golang-fips/openssl e1541889d8a8ad4eaf02630a8cae303206ef68c1
+	github.com/golang-fips/openssl-fips e1541889d8a8ad4eaf02630a8cae303206ef68c1
 )


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-4582