### PR TITLE
fix: Don't copy /etc/passpwd from the builder since appuser is added in runtime container.

### DIFF
--- a/build/dockerfiles/brew.Dockerfile
+++ b/build/dockerfiles/brew.Dockerfile
@@ -42,7 +42,6 @@ RUN microdnf -y install shadow-utils && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 
 USER appuser
-COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /usr/local/bin/configbump /usr/local/bin/configbump
 ENTRYPOINT [ "/usr/local/bin/configbump" ]
 

--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -40,6 +40,5 @@ RUN microdnf -y install shadow-utils && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 
 USER appuser
-COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /usr/local/bin/configbump /usr/local/bin/configbump
 ENTRYPOINT [ "/usr/local/bin/configbump" ]


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Don't copy `/etc/passpwd` from the builder since `appuser` is added in runtime container.
Previously, copy command overrode the `/etc/passpwd` file

### What issues does this PR fix or reference?
