### PR TITLE
Enable che-incubator configbump build support on s390x architecture

### DIFF
--- a/.github/workflows/next-build-multiarch.yml
+++ b/.github/workflows/next-build-multiarch.yml
@@ -29,10 +29,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64,arm64]
+        arch: [amd64,arm64,s390x]
     outputs:
       amd64: ${{ steps.result.outputs.amd64 }}
       arm64: ${{ steps.result.outputs.arm64 }}
+      s390x: ${{ steps.result.outputs.s390x }}
     steps:
       -
         name: "Checkout Che Configbump source code"
@@ -89,6 +90,10 @@ jobs:
           ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
           if [ -n "$ARM64_VERSION" ]; then
             AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          fi
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
+          if [ -n "$S390X_VERSION" ]; then
+            AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
           fi
           if [ -z "$AMEND" ]; then
             echo "[!] The job 'build-images' didn't provide any outputs. Can't create the manifest list."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64,arm64]
+        arch: [amd64,arm64,s390x]
     outputs:
       amd64: ${{ steps.result.outputs.amd64 }}
       arm64: ${{ steps.result.outputs.arm64 }}
+      s390x: ${{ steps.result.outputs.s390x }}
     steps:
       -
         name: "Checkout Che Dashboard source code"
@@ -86,9 +87,11 @@ jobs:
         run: |
           AMD64_VERSION="${{ needs['build-images'].outputs.amd64 }}"
           ARM64_VERSION="${{ needs['build-images'].outputs.arm64 }}"
+          S390X_VERSION="${{ needs['build-images'].outputs.s390x }}"
 
           if [[ -z "$AMD64_VERSION" || \
-               -z "$ARM64_VERSION" ]]; then
+               -z "$ARM64_VERSION" || \
+               -z "$S390X_VERSION" ]]; then
             echo "[!] The job 'build-images' fails on some of the architectures. Can't create complete manifest.";
             exit 1;
           fi
@@ -96,6 +99,7 @@ jobs:
           AMEND=""
           AMEND+=" --amend ${{ env.IMAGE }}:$AMD64_VERSION";
           AMEND+=" --amend ${{ env.IMAGE }}:$ARM64_VERSION";
+          AMEND+=" --amend ${{ env.IMAGE }}:$S390X_VERSION";
 
           docker manifest create ${{ env.IMAGE }}:${{ github.event.inputs.version }} $AMEND
           docker manifest push ${{ env.IMAGE }}:${{ github.event.inputs.version }}

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -21,7 +21,7 @@ WORKDIR /app
 COPY . ./
 
 #hadolint ignore=SC3010
-RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
+RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; elif [[ ${ARCH} == "s390x" ]]; then export ARCH="s390x"; fi && \
     go mod download && go mod verify && \
     go test -v  ./... && \
     # to test FIPS compliance, run https://github.com/openshift/check-payload#scan-a-container-or-operator-image against a built image


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
This PR enables support for building the `Che-incubator configbump` on the s390x architecture.
It updates and refines architecture compatibility logic and ensures successful builds on IBM Z running RHEL 9.2 (s390x).

### What issues does this PR fix or reference?
This is part of internal enablement for Che on s390x (IBM Z).

### Pre-built Test Image
A pre-built s390x image is available for testing: `docker pull quay.io/swasingh/configbump:s390x-next`

### Screenshot/screencast of this PR
<img width="1308" height="406" alt="Screenshot 2026-05-22 at 3 03 24 PM" src="https://github.com/user-attachments/assets/943a8559-2755-49d7-8870-d58164fda641" />

<img width="1682" height="506" alt="Screenshot 2026-05-22 at 3 04 20 PM" src="https://github.com/user-attachments/assets/0800843c-9d10-48a4-95a2-18119e576f9b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added s390x architecture support to build workflows and Docker image creation, enabling deployment on additional infrastructure platforms alongside existing amd64 and arm64 architectures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/che-incubator/configbump/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->